### PR TITLE
fix NixOS options description type

### DIFF
--- a/src/options_docsource.rs
+++ b/src/options_docsource.rs
@@ -1,27 +1,27 @@
 use crate::{
-    contains_insensitive_ascii,
-    starts_with_insensitive_ascii,
-    Cache,
-    DocEntry,
-    DocSource,
-    Errors,
+    contains_insensitive_ascii, starts_with_insensitive_ascii, Cache, DocEntry, DocSource, Errors,
     Lowercase,
 };
 use colored::*;
-use serde::{
-    Deserialize,
-    Serialize,
-};
-use std::{
-    collections::HashMap,
-    path::PathBuf,
-    process::Command,
-};
+use serde::{Deserialize, Serialize};
+use std::{collections::HashMap, fmt::Display, path::PathBuf, process::Command};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct OptionDescription {
+    _type: String,
+    text: String,
+}
+
+impl Display for OptionDescription {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.text)
+    }
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct OptionDocumentation {
     #[serde(default)]
-    description: String,
+    description: OptionDescription,
 
     #[serde(default, rename(serialize = "readOnly", deserialize = "readOnly"))]
     read_only: bool,


### PR DESCRIPTION
It seems that the json representation of NixOS options has changed from being a string to an object with 
```json
{
  "_type": "", 
  "text": "the description"
}
``` 
That made the deserialization of the resulting json fail for NixOS options.

I wasn't able to pinpoint when this change happened or if it applies to all versions, so comments are welcomed to fix this the best way possible :)

I think this would close https://github.com/nix-community/manix/issues/17