### PR TITLE
Fix evaluation of nix-darwin options

### DIFF
--- a/src/nix/darwin-options.nix
+++ b/src/nix/darwin-options.nix
@@ -8,7 +8,7 @@ let
     then attempt.value
     else fetchTarball "https://github.com/LnL7/nix-darwin/archive/refs/heads/master.tar.gz";
 
-  eval = import nix-darwin {configuration = {...}: {};};
+  eval = import nix-darwin {configuration = {config, ...}: { system.stateVersion = config.system.maxStateVersion; };};
   opts = eval.config.system.build.manual.optionsJSON;
 in
   runCommandLocal "options.json" {inherit opts;} ''


### PR DESCRIPTION
`system.stateVersion` must be set in the (trivial) configuration passed to nix-darwin, otherwise an error is raised (this is also how it's set [upstream](https://github.com/LnL7/nix-darwin/blob/bb81755a3674951724d79b8cba6bbff01409d44d/release.nix#L60)).

Probably fixes #22.